### PR TITLE
Add title and description support for photos

### DIFF
--- a/Video Game App/Data/API/FeedService.swift
+++ b/Video Game App/Data/API/FeedService.swift
@@ -7,6 +7,7 @@ struct Post: Codable, Identifiable {
     let id: UUID
     let user_id: UUID
     let image_url: String
+    let title: String?
     let description: String?
     let is_public: Bool
     let created_at: Date
@@ -34,6 +35,7 @@ struct Post: Codable, Identifiable {
         case user_id
         case image_url
         case storage_path
+        case title
         case description
         case is_public
         case created_at
@@ -45,6 +47,7 @@ struct Post: Codable, Identifiable {
         
         id = try container.decode(UUID.self, forKey: .id)
         user_id = try container.decode(UUID.self, forKey: .user_id)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         is_public = try container.decode(Bool.self, forKey: .is_public)
         created_at = try container.decode(Date.self, forKey: .created_at)
@@ -74,6 +77,7 @@ struct Post: Codable, Identifiable {
         try container.encode(id, forKey: .id)
         try container.encode(user_id, forKey: .user_id)
         try container.encode(image_url, forKey: .image_url)
+        try container.encodeIfPresent(title, forKey: .title)
         try container.encodeIfPresent(description, forKey: .description)
         try container.encode(is_public, forKey: .is_public)
         try container.encode(created_at, forKey: .created_at)
@@ -129,6 +133,7 @@ struct Comment: Codable, Identifiable {
 struct NewPost: Encodable {
     let user_id: UUID
     let image_url: String
+    let title: String?
     let description: String?
     let is_public: Bool
 }
@@ -357,7 +362,7 @@ class FeedService {
     }
     
     /// Creates a new post
-    func createPost(imageUrl: String, description: String?, isPublic: Bool = true) async throws -> Post {
+    func createPost(imageUrl: String, title: String?, description: String?, isPublic: Bool = true) async throws -> Post {
         guard let session = client.auth.currentSession else {
             throw NSError(domain: "FeedService", code: 401, userInfo: [
                 NSLocalizedDescriptionKey: "User not authenticated"
@@ -367,6 +372,7 @@ class FeedService {
         let newPost = NewPost(
             user_id: session.user.id,
             image_url: imageUrl,
+            title: title,
             description: description,
             is_public: isPublic
         )

--- a/Video Game App/Data/API/PhotoService.swift
+++ b/Video Game App/Data/API/PhotoService.swift
@@ -5,6 +5,7 @@ struct Photo: Codable {
     let id: UUID
     let user_id: UUID
     let image_url: String
+    let title: String?
     let description: String?
     let is_public: Bool
     let created_at: Date
@@ -14,6 +15,7 @@ struct NewPhoto: Encodable {
     let user_id: UUID
     let image_url: String
     let storage_path: String
+    let title: String
     let description: String
     let is_public: Bool
 }
@@ -29,6 +31,7 @@ class PhotoService {
     /// Uploads a Runware-generated image to Supabase storage,
     /// inserts a row in `photos` table, and returns a public URL for display.
     func saveRunwareImage(runwareURL: URL,
+                          title: String? = nil,
                           description: String? = nil,
                           isPublic: Bool = true) async throws -> String {
         
@@ -66,6 +69,7 @@ class PhotoService {
             user_id: userUUID,
             image_url: objectKey,   // ✅ matches actual Storage key
             storage_path: objectKey,
+            title: title ?? "",
             description: description ?? "",
             is_public: isPublic
         )

--- a/Video Game App/Data/ViewModels/FeedViewModel.swift
+++ b/Video Game App/Data/ViewModels/FeedViewModel.swift
@@ -134,9 +134,9 @@ class FeedViewModel: ObservableObject {
     // MARK: - Post Management
     
     /// Creates a new post
-    func createPost(imageUrl: String, description: String?) async -> Bool {
+    func createPost(imageUrl: String, title: String?, description: String?) async -> Bool {
         do {
-            let newPost = try await feedService.createPost(imageUrl: imageUrl, description: description)
+            let newPost = try await feedService.createPost(imageUrl: imageUrl, title: title, description: description)
             
             // Add the new post to the beginning of the feed
             posts.insert(newPost, at: 0)

--- a/Video Game App/INTEGRATION_GUIDE.md
+++ b/Video Game App/INTEGRATION_GUIDE.md
@@ -80,6 +80,7 @@ func uploadPhotoAndCreatePost(imageData: Data, title: String?, description: Stri
     let feedService = FeedService(client: SupabaseManager.shared.client)
     _ = try await feedService.createPost(
         imageUrl: photoURL,
+        title: title,
         description: description,
         isPublic: true
     )
@@ -330,6 +331,7 @@ func uploadPhoto(image: UIImage, description: String?) async {
         let feedService = FeedService(client: SupabaseManager.shared.client)
         _ = try await feedService.createPost(
             imageUrl: photoURL,
+            title: nil, // You can add title parameter here if needed
             description: description,
             isPublic: true
         )

--- a/Video Game App/INTEGRATION_GUIDE.md
+++ b/Video Game App/INTEGRATION_GUIDE.md
@@ -72,9 +72,9 @@ Modify your existing photo upload to also create a post in the feed:
 
 ```swift
 // In your existing PhotoService or wherever you handle photo uploads
-func uploadPhotoAndCreatePost(imageData: Data, description: String?) async throws {
+func uploadPhotoAndCreatePost(imageData: Data, title: String?, description: String?) async throws {
     // Your existing photo upload logic...
-    let photoURL = try await saveRunwareImage(runwareURL: imageURL, description: description)
+    let photoURL = try await saveRunwareImage(runwareURL: imageURL, title: title, description: description)
     
     // Now also create a post in the feed
     let feedService = FeedService(client: SupabaseManager.shared.client)

--- a/Video Game App/Pages/Camera/PhotoReviewView.swift
+++ b/Video Game App/Pages/Camera/PhotoReviewView.swift
@@ -199,7 +199,8 @@ struct PhotoReviewView: View {
                             let service = PhotoService(client: supabase)
                             _ = try await service.saveRunwareImage(
                                 runwareURL: runwareURL,
-                                description: title.trimmingCharacters(in: .whitespacesAndNewlines)
+                                title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+                                description: description.trimmingCharacters(in: .whitespacesAndNewlines)
                             )
                             
                             await galleryViewModel.refreshFromSupabase()

--- a/Video Game App/Pages/FeedView.swift
+++ b/Video Game App/Pages/FeedView.swift
@@ -151,7 +151,11 @@ struct PostCardView: View {
             // Engagement
             engagementInfo
             
-            // Description
+            // Title and Description (if available) - BELOW the image
+            if let title = post.title, !title.isEmpty {
+                postTitle(title)
+            }
+            
             if let description = post.description, !description.isEmpty {
                 postDescription(description)
             }
@@ -272,13 +276,20 @@ struct PostCardView: View {
         .padding(.horizontal, 16)
     }
     
-    private func postDescription(_ description: String) -> some View {
+    private func postTitle(_ title: String) -> some View {
         HStack(alignment: .top) {
-            Text(viewModel.getDisplayName(for: post))
-                .font(.subheadline)
+            Text(title)
+                .font(.headline)
                 .fontWeight(.semibold)
                 .foregroundColor(.primary)
             
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    private func postDescription(_ description: String) -> some View {
+        HStack(alignment: .top) {
             Text(description)
                 .font(.subheadline)
                 .foregroundColor(.primary)

--- a/Video Game App/Pages/GalleryView/GalleryDetailView.swift
+++ b/Video Game App/Pages/GalleryView/GalleryDetailView.swift
@@ -9,33 +9,19 @@ struct GalleryDetailView: View {
     @State private var showingDeleteAlert = false
     @State private var isDeleting = false
     
-    // Mock data for demo - in real app this would come from the photo object
-    private var mockTitle: String {
-        let titles = [
-            "Morning Coffee Quest",
-            "City Exploration Adventure",
-            "Work From Home Mission",
-            "Grocery Shopping Run",
-            "Evening Walk Discovery",
-            "Lunch Break Escape",
-            "Weekend Warrior Challenge",
-            "Daily Commute Journey"
-        ]
-        return titles.randomElement() ?? "Life Adventure"
+    // Real data from photo object
+    private var displayTitle: String {
+        if let photo = photo, let title = photo.title, !title.isEmpty {
+            return title
+        }
+        return "Untitled Adventure"
     }
     
-    private var mockDescription: String {
-        let descriptions = [
-            "Started the day with a perfect cup of coffee and some quiet reflection.",
-            "Explored the bustling city streets and discovered hidden gems around every corner.",
-            "Another productive day working from the comfort of home office.",
-            "Successfully navigated the grocery store maze and emerged victorious with supplies.",
-            "Took an evening stroll and found peace in the simple moments of life.",
-            "Escaped the daily grind for a quick lunch break and some fresh air.",
-            "Embraced the weekend warrior spirit with some outdoor activities.",
-            "Made the daily commute feel like an adventure through the urban landscape."
-        ]
-        return descriptions.randomElement() ?? "Another day in the adventure of life."
+    private var displayDescription: String {
+        if let photo = photo, let description = photo.description, !description.isEmpty {
+            return description
+        }
+        return ""
     }
     
     private var mockXP: Int {
@@ -62,7 +48,7 @@ struct GalleryDetailView: View {
                 VStack(alignment: .leading, spacing: 16) {
                     // Title and XP
                     HStack {
-                        Text(mockTitle)
+                        Text(displayTitle)
                             .font(.title2)
                             .fontWeight(.bold)
                         
@@ -94,11 +80,13 @@ struct GalleryDetailView: View {
                             .foregroundColor(.secondary)
                     }
                     
-                    // Description
-                    Text(mockDescription)
-                        .font(.body)
-                        .foregroundColor(.primary)
-                        .lineLimit(nil)
+                    // Description (only show if it exists)
+                    if !displayDescription.isEmpty {
+                        Text(displayDescription)
+                            .font(.body)
+                            .foregroundColor(.primary)
+                            .lineLimit(nil)
+                    }
                     
                     // Stats Section
                     VStack(alignment: .leading, spacing: 12) {

--- a/Video Game App/Supabase/migrations/202410301200_add_title_description_to_photos.sql
+++ b/Video Game App/Supabase/migrations/202410301200_add_title_description_to_photos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.photos
+ADD COLUMN IF NOT EXISTS title text,
+ADD COLUMN IF NOT EXISTS description text;


### PR DESCRIPTION
## Summary
- expand photo models and save routine to handle titles and descriptions
- forward title and description from camera UI to photo saving
- add migration for title and description columns in photos table

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f1e68fc83278c2f2bd0fb301c4c